### PR TITLE
167 nightly redeploys cf fix

### DIFF
--- a/.cg-deploy/deploy.sh
+++ b/.cg-deploy/deploy.sh
@@ -1,7 +1,7 @@
 set -e
 
 export PATH=$HOME:$PATH
-curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.26.0"
+curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.36.2"
 tar xzvf $HOME/cf.tgz -C $HOME
 
 cf install-plugin autopilot -f -r CF-Community

--- a/.cg-deploy/deploy.sh
+++ b/.cg-deploy/deploy.sh
@@ -1,9 +1,5 @@
 set -e
 
-export PATH=$HOME:$PATH
-curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.36.2"
-tar xzvf $HOME/cf.tgz -C $HOME
-
 cf install-plugin autopilot -f -r CF-Community
 
 API="https://api.fr.cloud.gov"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,13 @@ _run:
       cd ../server
       yarn install
 
+  install_cf_cli: &install_cf_cli
+    name: Install cf cli
+    command: |
+    export PATH=$HOME:$PATH
+    curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.36.2"
+    tar xzvf $HOME/cf.tgz -C $HOME
+
 version: 2
 jobs:
   run-all-other-tests:
@@ -276,6 +283,7 @@ jobs:
           command: |
             cd server
             yarn run docs
+      - run: *install_cf_cli
       - run:
           name: deploy
           command: |
@@ -332,6 +340,7 @@ jobs:
           command: |
             cd server
             yarn run docs
+      - run: *install_cf_cli
       - run:
           name: deploy
           command: |
@@ -343,6 +352,7 @@ jobs:
     docker:
       - image: circleci/node:8.9.4
     steps:
+      - run: *install_cf_cli
       - run:
           name: Install cf-recycle-plugin 1.0.0 release
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ _run:
   install_cf_cli: &install_cf_cli
     name: Install cf cli
     command: |
-    export PATH=$HOME:$PATH
-    curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.36.2"
-    tar xzvf $HOME/cf.tgz -C $HOME
+      export PATH=$HOME:$PATH
+      curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.36.2"
+      tar xzvf $HOME/cf.tgz -C $HOME
 
 version: 2
 jobs:


### PR DESCRIPTION
Install the `cf cli` so that the cf recycle plugin will work for nightly redeploys. 

Fix this failed build: https://circleci.com/gh/18F/fs-middlelayer-api/217