### PR TITLE
add smtp port

### DIFF
--- a/server/src/email/email-util.es6
+++ b/server/src/email/email-util.es6
@@ -60,6 +60,9 @@ emailUtil.send = (to, subject, body, html = false, attachments = false) => {
   if (attachments) {
     mailOptions.attachments = attachments;
   }
+  if(vcapConstants.SMTP_PORT){
+    mailOptions.port = vcapConstants.SMTP_PORT;
+  }
   if (vcapConstants.SMTP_HOST) {
     emailUtil.transporter.sendMail(mailOptions, error => {
       if (error) {

--- a/server/src/vcap-constants.es6
+++ b/server/src/vcap-constants.es6
@@ -82,6 +82,7 @@ const smtp = getUserProvided('smtp-service');
 vcapConstants.SMTP_HOST = smtp.smtp_server;
 vcapConstants.SMTP_USERNAME = smtp.username;
 vcapConstants.SMTP_PASSWORD = smtp.password;
+vcapConstants.SMTP_PORT = smtp.port;
 vcapConstants.SPECIAL_USE_ADMIN_EMAIL_ADDRESSES = smtp.admins;
 
 /** Pay.gov */


### PR DESCRIPTION
Add an optional port param for the node mailer SMTP config to handle the switch to the USDA mail proxy and test mail sends from port `25`