### PR TITLE
Fix sticky buttons in IE

### DIFF
--- a/frontend/src/app/_directives/scroll.directive.ts
+++ b/frontend/src/app/_directives/scroll.directive.ts
@@ -26,7 +26,8 @@ export class TrackScrollDirective implements OnInit {
     const offsetTop = this.element.nativeElement.offsetTop;
     const offsetHeight = this.element.nativeElement.offsetHeight;
     const offsetBottom = offsetTop + offsetHeight + Number(this.offset);
-    const scrollY: number = window.scrollY + window.innerHeight;
+    const pageYOffset = window.pageYOffset || document.documentElement.scrollTop;
+    const scrollY: number = pageYOffset + window.innerHeight;
 
     if (this.position === 'bottom' && offsetBottom <= scrollY) {
       this.trackScrollEnter.emit(true);

--- a/frontend/src/app/_services/util.service.ts
+++ b/frontend/src/app/_services/util.service.ts
@@ -101,7 +101,7 @@ export class UtilService {
       this.currentSubSection = fragment;
       if (element) {
         element.scrollIntoView(true);
-        const scrolledY = window.scrollY;
+        const scrolledY = window.pageYOffset || document.documentElement.scrollTop;
         window.scroll(0, scrolledY - 80);
         document.getElementById(fragment).focus();
         return fragment;


### PR DESCRIPTION
It looks like IE doesn't have support for `window.scrollY` based on https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY so we can get similar results by using `window.pageYOffset`. 

I updated the scrolling function that the button bar uses on the application details screen, as well as the `gotoHashtag` function which was causing IE to not have the correct offset when jumping to different sections of the form.

**Application details screen**
Before:
![screen shot 2018-06-15 at 12 32 41 pm](https://user-images.githubusercontent.com/1178494/41479710-127dca24-709a-11e8-89a1-6c9843a60268.png)
After:
![screen shot 2018-06-15 at 12 31 20 pm](https://user-images.githubusercontent.com/1178494/41479720-1716b1ea-709a-11e8-8da6-b2e08f0b10b5.png)

**Application form**
Before:
![screen shot 2018-06-15 at 12 43 41 pm](https://user-images.githubusercontent.com/1178494/41479752-3490c562-709a-11e8-88f5-29bcae1e816e.png)
After:
![screen shot 2018-06-15 at 12 42 45 pm](https://user-images.githubusercontent.com/1178494/41479760-3979045e-709a-11e8-92de-e50972c66492.png)
