### PR TITLE
change ng build configurations for new cli

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -53,12 +53,12 @@
               ]
             },
             "production": {
+              "aot": false,
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
@@ -70,18 +70,11 @@
               ]
             },
             "trees": {
+              "aot": false,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.trees.ts"
-                }
-              ]
-            },
-            "staging": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.staging.ts"
                 }
               ]
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,9 @@
   "license": "MIT",
   "scripts": {
     "build": "ng build",
-    "dist": "ng build --prod --env=prod --aot=false",
-    "dist-trees": "ng build --env=trees --aot=false",
-    "dist-staging": "ng build --prod --env=staging --aot=false",
-    "dist-prod": "ng build --prod --env=prod --aot=false",
+    "dist": "ng build --prod --configuration=prod",
+    "dist-trees": "ng build --configuration=trees",
+    "dist-prod": "ng build --prod --configuration=prod",
     "docs": "yarn run typedoc --out ./src/assets/typedoc --exclude '**/*.spec.ts' ./src/ --module commonjs",
     "e2e:ci": "ng e2e --port=4200",
     "e2e:cidkr": "ng e2e --port=4200 --protractor-config ./development-configurations/protractor.conf.js --specs=./e2e/authenticated/special-uses/application-noncommercial-group.e2e-spec.ts",

--- a/frontend/src/environments/environment.staging.ts
+++ b/frontend/src/environments/environment.staging.ts
@@ -1,8 +1,0 @@
-export const environment = {
-  production: false,
-  apiUrl: 'https://fs-intake-staging-api.app.cloud.gov/',
-  buildDate: 'Tue Jan 16 2018 17:06:56 GMT-0500 (EST)',
-  version: '',
-  envName: 'staging',
-  changeRequestForm: 'https://docs.google.com/forms/d/e/1FAIpQLSca7taTXY7xUTDvcnyR7rf7jkfvinBPtGqbNWgLBd3Dy6kH4Q/viewform'
-};


### PR DESCRIPTION
- define `--aot=false` in the configurations section of the `angular.json`
- convert deprecated `--environments` flag to `--configurations` which refs the configurations in the `angular-json`
- remove now defunct `staging` environment