### PR TITLE
Populate form when editing

### DIFF
--- a/frontend/src/app/application-forms/_services/application-fields.service.ts
+++ b/frontend/src/app/application-forms/_services/application-fields.service.ts
@@ -99,9 +99,11 @@ export class ApplicationFieldsService {
 
   phoneChangeSubscribers(parentForm, type) {
     parentForm.get(`${type}.tenDigit`).valueChanges.subscribe(value => {
-      parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
-      parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
-      parentForm.patchValue({ [type]: { number: value.substring(6, 10) } });
+      if (value) {
+        parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
+        parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
+        parentForm.patchValue({ [type]: { number: value.substring(6, 10) } });
+      }
     });
   }
 

--- a/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.ts
+++ b/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.ts
@@ -164,7 +164,7 @@ export class ApplicationNoncommercialGroupComponent implements OnInit {
     this.applicationService.getOne(id, `/special-uses/noncommercial/`).subscribe(
       application => {
         this.application = application;
-        this.applicationForm.setValue(application);
+        this.applicationForm.patchValue(application);
       },
       (e: any) => {
         this.apiErrors = e;


### PR DESCRIPTION
The field application service was trying to parse the additional phone number field even when it was blank which was causing an error. This adds a check to make sure a value is set before parsing it.