### PR TITLE
Add login.gov helper text to help me pick page

### DIFF
--- a/frontend/src/app/help-me-pick/help-me-pick.component.html
+++ b/frontend/src/app/help-me-pick/help-me-pick.component.html
@@ -33,14 +33,14 @@
 
     <div *ngIf="id == 7">
       <p class="message">You can apply online.</p>
-      <a routerLink="/applications/noncommercial-group-use/new" class="usa-button usa-button-secondary">Noncommercial permit</a>
-      <p><a class="learn-more-link" routerLink="/applications/noncommercial-group-use/learn-more" aria-label="Click here to learn more about the noncommercial permit.">Click here to learn more about this permit.</a></p>
+      <app-button link="/applications/noncommercial-group-use/new" buttonText="Noncommercial permit" btnAlt="true"></app-button>
+      <a routerLink="/applications/noncommercial-group-use/learn-more" class="learn-more-link display-block">Learn more about this permit</a>
     </div>
 
     <div *ngIf="id == 8">
       <p class="message">You can apply online.</p>
-      <a routerLink="/applications/temp-outfitters/new" class="usa-button usa-button-secondary">Temp outfitter's permit</a>
-      <p><a class="learn-more-link" routerLink="/applications/temp-outfitters/learn-more" aria-label="Click here to learn more about the temporary outfitter's permit.">Click here to learn more about this permit.</a></p>
+      <app-button link="/applications/temp-outfitters/new" buttonText="Temp outfitter's permit" btnAlt="true"></app-button>
+      <a routerLink="/applications/temp-outfitters/learn-more" class="learn-more-link display-block">Learn more about this permit</a>
     </div>
 
   </div>


### PR DESCRIPTION
Add some context about login.gov to the `Help Me Pick page`.

**Before:**
![screen shot 2018-07-11 at 11 34 16 am](https://user-images.githubusercontent.com/1178494/42583773-ae6e3512-84ff-11e8-99a4-bb9a051b705e.png)

**After:**
![screen shot 2018-07-11 at 11 33 44 am](https://user-images.githubusercontent.com/1178494/42583789-b56d9c0e-84ff-11e8-941d-52a6af4a2275.png)
![screen shot 2018-07-11 at 11 34 01 am](https://user-images.githubusercontent.com/1178494/42583793-b903c410-84ff-11e8-8fce-dc746fff27f3.png)
