### PR TITLE
delete unused key to populate fields

### DIFF
--- a/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.ts
+++ b/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.ts
@@ -161,6 +161,9 @@ export class ApplicationNoncommercialGroupComponent implements OnInit {
     this.applicationService.getOne(id, `/special-uses/noncommercial/`).subscribe(
       application => {
         this.application = application;
+        if (this.application.controlNumber) {
+          delete this.application.controlNumber;
+        }
         this.applicationForm.setValue(application);
       },
       (e: any) => {


### PR DESCRIPTION
the angular API expects a 1:1 ratio for formControls and object keys, but we don't have a `controlNumber` at this point so the form breaks. Deleting that key works (and you can fully submit the app with this), but from an angular perspective, I'm not sure if this is the best way to handle that.

The other way would be to pass a hidden field? But seems like that's not particularly Angular 2 friendly as well.