### PR TITLE
Repopulate temp outfitter form when editing

### DIFF
--- a/frontend/src/app/application-forms/_services/application-fields.service.ts
+++ b/frontend/src/app/application-forms/_services/application-fields.service.ts
@@ -99,9 +99,11 @@ export class ApplicationFieldsService {
 
   phoneChangeSubscribers(parentForm, type) {
     parentForm.get(`${type}.tenDigit`).valueChanges.subscribe(value => {
-      parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
-      parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
-      parentForm.patchValue({ [type]: { number: value.substring(6, 10) } });
+      if (value) {
+        parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
+        parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
+        parentForm.patchValue({ [type]: { number: value.substring(6, 10) } });
+      }
     });
   }
 

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.ts
@@ -258,7 +258,7 @@ export class TemporaryOutfittersComponent implements DoCheck, OnInit {
       application => {
         this.application = application;
         this.applicationId = application.applicationId;
-        this.applicationForm.setValue(this.application);
+        this.applicationForm.patchValue(this.application);
         this.getFiles(this.application.applicationId);
       },
       (e: any) => {


### PR DESCRIPTION
Populate the form with required models and ignore blank or optional models.