### PR TITLE
Define docker config in frontend-e2e project

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -160,6 +160,16 @@
       "architect": {
         "e2e": {
           "builder": "@angular-devkit/build-angular:protractor",
+          "configurations": {
+            "docker": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment-docker.ts"
+                }
+              ]
+            }
+          },
           "options": {
             "protractorConfig": "./protractor.conf.js",
             "devServerTarget": "frontend:serve"


### PR DESCRIPTION
The `frontend-e2e` project is missing the `docker` configuration, this copies the config from the main `frontend` project.