### PR TITLE
Run docker job on all CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,10 +386,7 @@ workflows:
     jobs:
       - run-all-other-tests
       - run-e2e
-      - build-docker:
-          filters:
-            branches:
-              only: dev
+      - build-docker
       - run-pa11y:
           filters:
             branches:


### PR DESCRIPTION
To help with troubleshooting build errors.