### PR TITLE
Add contact placeholders to learn more pages

### DIFF
--- a/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
+++ b/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
@@ -54,9 +54,12 @@ export class NoncommercialLearnMoreComponent {
         <p>If you have questions or need to contact the permit staff at the National Forest Service, please use a method listed below.</p>
         <div class="contact-details">
           <h3>Noncommercial contact</h3>
-          <p class="title-description">Interesting title description.</p>
-          <p class="contact"><strong>Phone: </strong>(800) 333-5555</p>
-          <p class="contact"><strong>Email: </strong><a href="mailto:info@fs.usda.gov">info@fs.usda.gov</a></p>
+          <p class="title-description">
+            Sue Sherman-Biery<br>
+            <span class="italic">Special use administrator</span>
+          </p>
+          <p class="contact"><strong>Phone: </strong>(360) 854-2660</p>
+          <p class="contact"><strong>Email: </strong><a href="mailto:sshermanbiery@fs.fed.us">sshermanbiery@fs.fed.us</a></p>
         </div>`
       }
     ];

--- a/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
+++ b/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
@@ -46,6 +46,18 @@ export class NoncommercialLearnMoreComponent {
         If the permit is denied, an officer is required to explain the reasons to the applicant in writing.</p>
 
         <p>For more information about non-commercial group use and regulations, <a href="https://www.fs.fed.us/specialuses/special_non_com_uses.shtml">visit our FAQ page</a></p>`
+      },
+      {
+        sectionName: 'Contact us',
+        type: 'anchor',
+        sectionCopy: `
+        <p>If you have questions or need to contact the permit staff at the National Forest Service, please use a method listed below.</p>
+        <div class="contact-details">
+          <h3>Noncommercial contact</h3>
+          <p class="title-description">Interesting title description.</p>
+          <p class="contact"><strong>Phone: </strong>(800) 333-5555</p>
+          <p class="contact"><strong>Email: </strong><a href="mailto:info@fs.usda.gov">info@fs.usda.gov</a></p>
+        </div>`
       }
     ];
   }

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters-learn-more.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters-learn-more.component.ts
@@ -140,6 +140,18 @@ first-served basis.</p>
         <p>For more information on Forest Service outfitter and guide policies and
 regulations, <a href="https://www.fs.fed.us/specialuses/special_outfitting.shtml">visit the national website</a>.</p>
         `
+      },
+      {
+        sectionName: 'Contact us',
+        type: 'anchor',
+        sectionCopy: `
+        <p>If you have questions or need to contact the permit staff at the National Forest Service, please use a method listed below.</p>
+        <div class="contact-details">
+          <h3>Temp outfitter contact</h3>
+          <p class="title-description">Interesting title description.</p>
+          <p class="contact"><strong>Phone: </strong>(800) 333-5555</p>
+          <p class="contact"><strong>Email: </strong><a href="mailto:info@fs.usda.gov">info@fs.usda.gov</a></p>
+        </div>`
       }
     ];
   }

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters-learn-more.component.ts
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters-learn-more.component.ts
@@ -148,9 +148,12 @@ regulations, <a href="https://www.fs.fed.us/specialuses/special_outfitting.shtml
         <p>If you have questions or need to contact the permit staff at the National Forest Service, please use a method listed below.</p>
         <div class="contact-details">
           <h3>Temp outfitter contact</h3>
-          <p class="title-description">Interesting title description.</p>
-          <p class="contact"><strong>Phone: </strong>(800) 333-5555</p>
-          <p class="contact"><strong>Email: </strong><a href="mailto:info@fs.usda.gov">info@fs.usda.gov</a></p>
+          <p class="title-description">
+            Sue Sherman-Biery<br>
+            <span class="italic">Special use administrator</span>
+          </p>
+          <p class="contact"><strong>Phone: </strong>(360) 854-2660</p>
+          <p class="contact"><strong>Email: </strong><a href="mailto:sshermanbiery@fs.fed.us">sshermanbiery@fs.fed.us</a></p>
         </div>`
       }
     ];

--- a/frontend/src/sass/elements/_typography.scss
+++ b/frontend/src/sass/elements/_typography.scss
@@ -43,3 +43,7 @@ h1 {
 .cursor-text {
   cursor: text;
 }
+
+.italic {
+  font-style: italic;
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -553,7 +553,7 @@ amqplib@^0.5.2:
     readable-stream "1.x >=1.1.9"
     safe-buffer "^5.0.1"
 
-angular2-csv@^0.2.5:
+angular2-csv@0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/angular2-csv/-/angular2-csv-0.2.5.tgz#8179f4392ed5c62b4043bf819e3bfc1ee8abf8f3"
 


### PR DESCRIPTION
Adding contact information to temp outfitter and non-commercial learn more pages.

![screen shot 2018-08-01 at 2 55 28 pm](https://user-images.githubusercontent.com/1178494/43542418-ea749140-959a-11e8-8034-1e0d6abc2ed5.png)

