### PR TITLE
don't store ununused unauth test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,6 @@ jobs:
       - store_artifacts:
           path: frontend/e2e-test-results
           prefix: e2e-results
-      - store_artifacts:
-          path: frontend/e2e-unauth-test-results
-          prefix: unauth-e2e-results
 
   run-pa11y:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,6 @@ jobs:
           name: Run unauthenticated e2e tests
           command: |
             .circleci/run-e2e.sh -u
-      - store_test_results:
-          path: test-results
       - run:
           name: Install dependencies and clean s3 bucket
           command: ./.circleci/clean-s3-bucket.sh


### PR DESCRIPTION
additional cleanup of the circle config for `e2e` tests