### PR TITLE
Only accept numbers in numeric fields

### DIFF
--- a/frontend/src/app/application-forms/fields/noncommercial-fields.component.html
+++ b/frontend/src/app/application-forms/fields/noncommercial-fields.component.html
@@ -10,7 +10,7 @@
 
     <label id="participants-label" class="usa-input">Estimated number of participants</label>
     <span id="participants-hint-text" class="help-text usa-form-hint">Please provide the number of event participants.</span>
-    <input id="participants" type="number" formControlName="numberParticipants" aria-required="true" min="1"
+    <input id="participants" type="number" (keypress)="numberOnly($event)" formControlName="numberParticipants" aria-required="true" min="1"
       [attr.aria-labelledby]="afs.labelledBy(noncommercialFields.controls.numberParticipants, 'participants-label participants-hint-text', 'participants-error')"
       [attr.aria-invalid]="afs.hasError(noncommercialFields.controls.numberParticipants)"
     />
@@ -18,7 +18,7 @@
 
     <label id="spectators-label" class="usa-input">Estimated number of spectators</label>
     <span id="spectators-hint-text" class="help-text usa-form-hint">If your event will have spectators (such as a sporting event), please provide the number of spectators.</span>
-    <input id="spectators" type="number" formControlName="numberSpectators" aria-required="true"
+    <input id="spectators" type="number" (keypress)="numberOnly($event)" formControlName="numberSpectators" aria-required="true"
       [attr.aria-labelledby]="afs.labelledBy(noncommercialFields.controls.numberSpectators, 'spectators-label spectators-hint-text', 'spectators-error')"
       [attr.aria-invalid]="afs.hasError(noncommercialFields.controls.numberSpectators)"
     />

--- a/frontend/src/app/application-forms/fields/noncommercial-fields.component.ts
+++ b/frontend/src/app/application-forms/fields/noncommercial-fields.component.ts
@@ -11,8 +11,15 @@ import { ApplicationFieldsService } from '../_services/application-fields.servic
 export class NoncommercialFieldsComponent implements OnInit {
   @Input() parentForm: FormGroup;
   formName: string;
-
   noncommercialFields: FormGroup;
+
+  numberOnly(event): boolean {
+    const charCode = (event.which) ? event.which : event.keyCode;
+    if (charCode > 31 && (charCode < 48 || charCode > 57)) {
+      return false;
+    }
+    return true;
+  }
 
   constructor(private formBuilder: FormBuilder, public afs: ApplicationFieldsService) {}
 


### PR DESCRIPTION
This restricts the `Please provide the number of event participants.` and `If your event will have spectators (such as a sporting event), please provide the number of spectators.` to numbers only. 

I was hoping to make this more DRY by making it a directive like https://www.davebennett.tech/angular-4-input-numbers-directive/ but from my testing there seems to be some issues with that approach and reactive forms. Might be worth revisiting if we find we need a similar solution on a larger set of inputs.
