### PR TITLE
Add url to application to transactional emails

### DIFF
--- a/server/src/email/templates/noncommercial/application-accepted.es6
+++ b/server/src/email/templates/noncommercial/application-accepted.es6
@@ -4,6 +4,8 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -30,6 +32,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
+You can view your application here: ${userApplicationUrl}
 
 Contact us
 *********************************

--- a/server/src/email/templates/noncommercial/application-accepted.es6
+++ b/server/src/email/templates/noncommercial/application-accepted.es6
@@ -4,7 +4,7 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -32,7 +32,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 Contact us
 *********************************

--- a/server/src/email/templates/noncommercial/application-cancelled.es6
+++ b/server/src/email/templates/noncommercial/application-cancelled.es6
@@ -2,7 +2,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -20,7 +20,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 Contact us
 **************************************

--- a/server/src/email/templates/noncommercial/application-cancelled.es6
+++ b/server/src/email/templates/noncommercial/application-cancelled.es6
@@ -2,6 +2,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: `Your ${application.eventName} permit application to the Mt. Baker-Snoqualmie National Forest has been cancelled.`,
@@ -18,6 +20,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
+You can view your application here: ${userApplicationUrl}
 
 Contact us
 **************************************

--- a/server/src/email/templates/noncommercial/application-rejected.es6
+++ b/server/src/email/templates/noncommercial/application-rejected.es6
@@ -4,7 +4,7 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -30,7 +30,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 If you would like to submit another permit application visit ${vcapConstants.INTAKE_CLIENT_BASE_URL}.
 

--- a/server/src/email/templates/noncommercial/application-rejected.es6
+++ b/server/src/email/templates/noncommercial/application-rejected.es6
@@ -4,6 +4,8 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -27,6 +29,8 @@ End date: ${moment(application.noncommercialFieldsEndDateTime, util.datetimeForm
 Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
+
+You can view your application here: ${userApplicationUrl}
 
 If you would like to submit another permit application visit ${vcapConstants.INTAKE_CLIENT_BASE_URL}.
 

--- a/server/src/email/templates/noncommercial/application-remove-hold.es6
+++ b/server/src/email/templates/noncommercial/application-remove-hold.es6
@@ -2,7 +2,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -28,7 +28,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/noncommercial/application-remove-hold.es6
+++ b/server/src/email/templates/noncommercial/application-remove-hold.es6
@@ -2,6 +2,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -26,6 +28,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
+You can view your application here: ${userApplicationUrl}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/noncommercial/application-review.es6
+++ b/server/src/email/templates/noncommercial/application-review.es6
@@ -2,6 +2,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -24,6 +26,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
+You can view your application here: ${userApplicationUrl}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/noncommercial/application-review.es6
+++ b/server/src/email/templates/noncommercial/application-review.es6
@@ -2,7 +2,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -26,7 +26,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/noncommercial/application-submitted-confirmation.es6
+++ b/server/src/email/templates/noncommercial/application-submitted-confirmation.es6
@@ -3,6 +3,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'Your noncommercial permit application has been submitted for review!',
@@ -25,6 +27,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
+You can view your application here: ${userApplicationUrl}
 
 What happens next?
 **************************************

--- a/server/src/email/templates/noncommercial/application-submitted-confirmation.es6
+++ b/server/src/email/templates/noncommercial/application-submitted-confirmation.es6
@@ -3,7 +3,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -27,7 +27,7 @@ Number of participants: ${application.noncommercialFieldsNumberParticipants}
 Number of spectators: ${application.noncommercialFieldsSpectatorCount}
 Location: ${application.noncommercialFieldsLocationDescription}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 What happens next?
 **************************************

--- a/server/src/email/templates/temp-outfitter/application-accepted.es6
+++ b/server/src/email/templates/temp-outfitter/application-accepted.es6
@@ -4,7 +4,7 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -36,7 +36,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 Contact us
 *********************************

--- a/server/src/email/templates/temp-outfitter/application-accepted.es6
+++ b/server/src/email/templates/temp-outfitter/application-accepted.es6
@@ -4,6 +4,8 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -34,6 +36,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
+You can view your application here: ${userApplicationUrl}
 
 Contact us
 *********************************

--- a/server/src/email/templates/temp-outfitter/application-cancelled.es6
+++ b/server/src/email/templates/temp-outfitter/application-cancelled.es6
@@ -3,7 +3,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -25,7 +25,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 Contact us
 **************************************

--- a/server/src/email/templates/temp-outfitter/application-cancelled.es6
+++ b/server/src/email/templates/temp-outfitter/application-cancelled.es6
@@ -3,6 +3,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'Your following permit application to the Mt. Baker-Snoqualmie National Forest has been cancelled.',
@@ -23,6 +25,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
+You can view your application here: ${userApplicationUrl}
 
 Contact us
 **************************************

--- a/server/src/email/templates/temp-outfitter/application-hold.es6
+++ b/server/src/email/templates/temp-outfitter/application-hold.es6
@@ -3,7 +3,7 @@ const vcapConstants = require('../../../vcap-constants.es6');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -35,7 +35,7 @@ module.exports = application => {
     Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
     Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-    You can view your application here: ${userApplicationUrl}
+    ${userApplicationLink}
 
     What happens next?
     **************************************

--- a/server/src/email/templates/temp-outfitter/application-hold.es6
+++ b/server/src/email/templates/temp-outfitter/application-hold.es6
@@ -3,6 +3,8 @@ const vcapConstants = require('../../../vcap-constants.es6');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: `An update on your recent permit application to the Forest Service.`,
@@ -33,6 +35,7 @@ module.exports = application => {
     Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
     Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
+    You can view your application here: ${userApplicationUrl}
 
     What happens next?
     **************************************

--- a/server/src/email/templates/temp-outfitter/application-rejected.es6
+++ b/server/src/email/templates/temp-outfitter/application-rejected.es6
@@ -4,7 +4,7 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -34,7 +34,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 If you would like to submit another permit application visit ${vcapConstants.INTAKE_CLIENT_BASE_URL}.
 

--- a/server/src/email/templates/temp-outfitter/application-rejected.es6
+++ b/server/src/email/templates/temp-outfitter/application-rejected.es6
@@ -4,6 +4,8 @@ const util = require('../../../services/util.es6');
 const vcapConstants = require('../../../vcap-constants.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -31,6 +33,8 @@ End date: ${moment(application.tempOutfitterFieldsActDescFieldsEndDateTime, util
 Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
+
+You can view your application here: ${userApplicationUrl}
 
 If you would like to submit another permit application visit ${vcapConstants.INTAKE_CLIENT_BASE_URL}.
 

--- a/server/src/email/templates/temp-outfitter/application-review.es6
+++ b/server/src/email/templates/temp-outfitter/application-review.es6
@@ -3,6 +3,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -29,6 +31,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
+You can view your application here: ${userApplicationUrl}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/temp-outfitter/application-review.es6
+++ b/server/src/email/templates/temp-outfitter/application-review.es6
@@ -3,7 +3,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -31,7 +31,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 What happens next?
 *********************************

--- a/server/src/email/templates/temp-outfitter/application-submitted-confirmation.es6
+++ b/server/src/email/templates/temp-outfitter/application-submitted-confirmation.es6
@@ -3,7 +3,7 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const userApplicationUrl = util.userApplicationUrl(application);
+  const userApplicationLink = util.userApplicationLink(application);
 
   return {
     to: application.applicantInfoEmailAddress,
@@ -31,7 +31,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
-You can view your application here: ${userApplicationUrl}
+${userApplicationLink}
 
 What happens next?
 **************************************

--- a/server/src/email/templates/temp-outfitter/application-submitted-confirmation.es6
+++ b/server/src/email/templates/temp-outfitter/application-submitted-confirmation.es6
@@ -3,6 +3,8 @@ const moment = require('moment');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
+  const userApplicationUrl = util.userApplicationUrl(application);
+
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'Your temporary outfitter permit application has been submitted for review.',
@@ -29,6 +31,7 @@ Number of trips: ${application.tempOutfitterFieldsActDescFieldsNumTrips}
 Number of participants: ${application.tempOutfitterFieldsActDescFieldsPartySize}
 Services: ${application.tempOutfitterFieldsActDescFieldsServProvided}
 
+You can view your application here: ${userApplicationUrl}
 
 What happens next?
 **************************************

--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -346,13 +346,36 @@ util.businessNameElsePersonalName = application => {
  * @param {Object} application - application object
  * @return {string} - application url
  */
-util.userApplicationUrl = application => {
+util.userApplicationLink = application => {
   const applicationType = application.type;
   const applicationID = application.appControlNumber;
+  const applicationStatus = application.status;
 
-  const applicationUrl = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/user/applications/${applicationType}/${applicationID}`;
+  let status;
+  switch (applicationStatus) {
+  case 'Accepted':
+    status = 'accepted application';
+    break;
+  case 'Hold':
+    status = 'application which needs additional information';
+    break;
+  case 'Rejected':
+    status = 'application';
+    break;
+  case 'Review':
+    status = 'application which is under review';
+    break;
+  case 'Cancelled':
+    status = 'cancelled application';
+    break;
+  case 'Submitted':
+    status = 'submitted application';
+  }
 
-  return applicationUrl;
+  const text = `You can view your ${status} here:`;
+  const url = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/user/applications/${applicationType}/${applicationID}`;
+
+  return `${text} ${url}`;
 };
 
 /**
@@ -440,7 +463,7 @@ util.logControllerAction = (req, controller, applicationOrPermit) => {
     role = util.getUserRole(req);
     permitID = applicationOrPermit.applicationId;
   }
-  
+
   logger.info(`CONTROLLER: ${req.method}:${controller} by ${userID}:${role} for ${permitID} at ${eventTime}`);
 };
 

--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -341,6 +341,21 @@ util.businessNameElsePersonalName = application => {
 };
 
 /**
+ * @function userApplicationUrl - Get the user's application URL
+ * based on the data in the permit application.
+ * @param {Object} application - application object
+ * @return {string} - application url
+ */
+util.userApplicationUrl = application => {
+  const applicationType = application.type;
+  const applicationID = application.appControlNumber;
+
+  const applicationUrl = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/user/applications/${applicationType}/${applicationID}`;
+
+  return applicationUrl;
+};
+
+/**
  * @function getRandomString - Create a random hex string.
  * @param {integer} length - random string to be length
  * @return {string} - random string

--- a/server/test/util.spec.es6
+++ b/server/test/util.spec.es6
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 
+const vcapConstants = require('../src/vcap-constants.es6');
 const util = require('../src/services/util.es6');
 
 describe('util tests', () => {
@@ -75,6 +76,33 @@ describe('util tests', () => {
       process.argv[2] = 'user'
       expect(util.localUser()).to.equal('user');
       process.argv.splice(2,1);
+    });
+  });
+
+  describe('userApplicationLink', () => {
+    it('should return the correct application url and accompanying link text', () => {
+      const statuses = [
+        { state: 'Accepted', text: 'accepted application'},
+        { state: 'Rejected', text: 'application'},
+        { state: 'Hold', text: 'application which needs additional information'},
+        { state: 'Review', text: 'application which is under review'},
+        { state: 'Cancelled', text: 'cancelled application'},
+        { state: 'Submitted', text: 'submitted application'}
+      ];
+      const testApp = {
+        type: 'noncommercial',
+        appControlNumber: '1d1ae92b-c1da-4933-9425-d64cad5561dd',
+      };
+      const url = vcapConstants.INTAKE_CLIENT_BASE_URL;
+
+      statuses.forEach((status) => {
+        testApp.status = status.state;
+
+        expect(util.userApplicationLink(testApp)).to.equal(
+          `You can view your ${status.text} here: ${url}/user/applications/noncommercial/1d1ae92b-c1da-4933-9425-d64cad5561dd`
+        );
+      });
+
     });
   });
 });


### PR DESCRIPTION
This adds a link to the user's application after the `Application Details` section in the following format:

```
You can view your application here: https://openforest.fs.usda.gov/user/applications/noncommercial/1d1ae92b-c1da-4933-9425-d64cad5561dd
```
I added the link to all of the transactional emails a user could receive for noncommercial/temp-outfitter, with the exception of the `Hold` emails since they already had a direct link in them to edit the form.