### PR TITLE
Handle case where 0 is entered as participant/spectator value

### DIFF
--- a/frontend/e2e/authenticated/special-uses/application-noncommercial-group.e2e-spec.ts
+++ b/frontend/e2e/authenticated/special-uses/application-noncommercial-group.e2e-spec.ts
@@ -158,4 +158,35 @@ describe('Apply for a noncommercial group use permit', () => {
     element(by.id('submit-application')).click();
     expect<any>(element(by.css('app-root h1')).getText()).toEqual('Submitted for review!');
   });
+
+  it('should show a warning with less than 75 participants', () => {
+    page.navigateTo();
+    const ec = protractor.ExpectedConditions;
+    browser.wait(ec.presenceOf(element(by.id('organization-label'))));
+    element(by.id('organization-label')).click();
+    element(by.id('participants')).sendKeys('0');
+    element(by.id('spectators')).sendKeys('0');
+    expect<any>(element(by.id('total-attendees-error')).getText()).toEqual('It appears you have entered fewer than 75 total attendees. For fewer than 75, you do not need a permit.');
+    element(by.id('participants')).clear().then(function() {
+      element(by.id('participants')).sendKeys('5');
+    });
+    element(by.id('spectators')).clear().then(function() {
+      element(by.id('spectators')).sendKeys('0');
+    });
+    expect<any>(element(by.id('total-attendees-error')).getText()).toEqual('It appears you have entered fewer than 75 total attendees. For fewer than 75, you do not need a permit.');
+    element(by.id('participants')).clear().then(function() {
+      element(by.id('participants')).sendKeys('5');
+    });
+    element(by.id('spectators')).clear().then(function() {
+      element(by.id('spectators')).sendKeys('5');
+    });
+    expect<any>(element(by.id('total-attendees-error')).getText()).toEqual('It appears you have entered fewer than 75 total attendees. For fewer than 75, you do not need a permit.');
+    element(by.id('participants')).clear().then(function() {
+      element(by.id('participants')).sendKeys('50');
+    });
+    element(by.id('spectators')).clear().then(function() {
+      element(by.id('spectators')).sendKeys('100');
+    });
+    expect<any>(element(by.id('total-attendees-error')).isPresent()).toBeFalsy();
+  });
 });

--- a/frontend/src/app/application-forms/fields/noncommercial-fields.component.ts
+++ b/frontend/src/app/application-forms/fields/noncommercial-fields.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { alphanumericValidator } from '../validators/alphanumeric-validation';
 import { numberValidator } from '../validators/number-validation';
 import { ApplicationFieldsService } from '../_services/application-fields.service';
+import { isNumeric } from 'rxjs/util/isNumeric';
 
 @Component({
   selector: 'app-noncommercial-fields',
@@ -57,7 +58,7 @@ export class NoncommercialFieldsComponent implements OnInit {
     const numberParticipants = group.controls.numberParticipants;
     const totalAttendees = numberSpectators.value + numberParticipants.value;
 
-    if (numberParticipants.value && numberSpectators.value && totalAttendees < 75) {
+    if (isNumeric(numberParticipants.value) && isNumeric(numberSpectators.value) && totalAttendees < 75) {
       return { notEnoughAttendees: true };
     }
     return null;


### PR DESCRIPTION
Currently `numberSpectators.value` evaluates as false when `0` is entered, this adds a more thorough number check  to handle those cases.