### PR TITLE
Email tweaks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+Resolves Issue #[X](https://github.com/18F/fs-permit-platform/issues/Addnumber)
+
+*Describe the pull request here, including any supplemental information needed to understand it.*
+
+## Impacted Areas of the Site
+
+## Optional Screenshots
+
+## This pull request changes...
+- [ ] expected change 1
+- [ ] expected change 2
+
+## This pull request is ready to merge when...
+- [ ] Tests have been updated (and all tests are passing)
+- [ ] This code has been reviewed by someone other than the original author
+- [ ] The change has been documented
+  - [ ] Associated OpenAPI documentation has been updated
+

--- a/server/src/email/templates/noncommercial/application-submitted-admin-confirmation.es6
+++ b/server/src/email/templates/noncommercial/application-submitted-admin-confirmation.es6
@@ -4,8 +4,7 @@ const vcapConstants = require('../../../vcap-constants.es6');
 const util = require('../../../services/util.es6');
 
 module.exports = application => {
-  const applicationUrl = `${vcapConstants.INTAKE_CLIENT_BASE_URL}\
-  /admin/applications/noncommercial/${application.appControlNumber}`;
+  const applicationUrl = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/admin/applications/noncommercial/${application.appControlNumber}`;
 
   return {
     to: vcapConstants.SPECIAL_USE_ADMIN_EMAIL_ADDRESSES,

--- a/server/src/email/templates/special-use-common/application-hold.es6
+++ b/server/src/email/templates/special-use-common/application-hold.es6
@@ -1,8 +1,11 @@
 const defaultForestContact = require('../default-special-use-contact-info.es6');
-const util = require('../../../services/util.es6');
+const vcapConstants = require('../vcap-constants.es6');
 
 
 module.exports = (application, defaultApplicationDetails) => {
+  const editURLAppType = (application.type == 'noncommericial') ? 'noncommericial-group-use' : 'temp-outfitters';
+  const editLink = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/applications/\
+  ${editURLAppType}/${application.appControlNumber}/edit`;
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',
@@ -14,7 +17,7 @@ module.exports = (application, defaultApplicationDetails) => {
 
     ${application.applicantMessage}
 
-    Login at ${util.userApplicationLink(application, false).url}/edit
+    Login at ${editLink}
 
 
     ${defaultApplicationDetails.text(application)}
@@ -38,7 +41,7 @@ module.exports = (application, defaultApplicationDetails) => {
      due to insufficient information. Please log in, provide the
       requested information below, and save your application.</p>
     <p>${application.applicantMessage}</p>
-    <p><a href="${util.userApplicationLink(application, false).url}/edit">
+    <p><a href="${editLink}">
     Login and edit your application
     </a></p>
     ${defaultApplicationDetails.html(application)}

--- a/server/src/email/templates/special-use-common/application-hold.es6
+++ b/server/src/email/templates/special-use-common/application-hold.es6
@@ -4,8 +4,7 @@ const vcapConstants = require('../vcap-constants.es6');
 
 module.exports = (application, defaultApplicationDetails) => {
   const editURLAppType = (application.type == 'noncommericial') ? 'noncommericial-group-use' : 'temp-outfitters';
-  const editLink = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/applications/\
-  ${editURLAppType}/${application.appControlNumber}/edit`;
+  const editLink = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/applications/${editURLAppType}/${application.appControlNumber}/edit`;
   return {
     to: application.applicantInfoEmailAddress,
     subject: 'An update on your recent permit application to the Forest Service.',

--- a/server/src/email/templates/special-use-common/application-hold.es6
+++ b/server/src/email/templates/special-use-common/application-hold.es6
@@ -3,7 +3,7 @@ const vcapConstants = require('../../../vcap-constants.es6');
 
 
 module.exports = (application, defaultApplicationDetails) => {
-  const editURLAppType = (application.type == 'noncommericial') ? 'noncommericial-group-use' : 'temp-outfitters';
+  const editURLAppType = (application.type == 'noncommercial') ? 'noncommercial-group-use' : 'temp-outfitters';
   const editLink = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/applications/${editURLAppType}/${application.appControlNumber}/edit`;
   return {
     to: application.applicantInfoEmailAddress,

--- a/server/src/email/templates/special-use-common/application-hold.es6
+++ b/server/src/email/templates/special-use-common/application-hold.es6
@@ -1,5 +1,5 @@
 const defaultForestContact = require('../default-special-use-contact-info.es6');
-const vcapConstants = require('../vcap-constants.es6');
+const vcapConstants = require('../../../vcap-constants.es6');
 
 
 module.exports = (application, defaultApplicationDetails) => {

--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -375,7 +375,7 @@ util.userApplicationLink = (application, plainText) => {
   if (plainText === true) {
     text = `You can view your ${status} here`;
   } else {
-    text = `View you ${status} here`;
+    text = `View your ${status} here`;
   }
   const url = `${vcapConstants.INTAKE_CLIENT_BASE_URL}/user/applications/${applicationType}/${applicationID}`;
   return {text, url};

--- a/server/test/util.spec.es6
+++ b/server/test/util.spec.es6
@@ -73,7 +73,7 @@ describe('util tests', () => {
     });
 
     it('set the local user as an admin', () => {
-      process.argv[2] = 'user'
+      process.argv[2] = 'user';
       expect(util.localUser()).to.equal('user');
       process.argv.splice(2,1);
     });
@@ -95,7 +95,7 @@ describe('util tests', () => {
       };
       const url = vcapConstants.INTAKE_CLIENT_BASE_URL;
 
-      statuses.forEach((status,) => {
+      statuses.forEach( status => {
         testApp.status = status.state;
         const userLink = util.userApplicationLink(testApp, true);
         expect(userLink.text).to.equal(


### PR DESCRIPTION
## Summary
Resolves Issue #[213](https://github.com/18F/fs-permit-platform/issues/213)

*Describe the pull request here, including any supplemental information needed to understand it.*
Addresses the broken links back to special use application HTML emails.

One thing of note is that the noncommericial routes alternate between `/noncommericial/ `and `/noncommericial-group-use/` and we may want to make it more consistent.



## Impacted Areas of the Site
* Special use emails created by the server [Server/src/emails]
* Github repo - by creating a PR Template

## Optional Screenshots
NA

## This pull request changes...
- [ ] ability to log back in when application is put on hold
- [ ] admins to log back in when receive a new special use application

## This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated Swagger documentation has been updated

